### PR TITLE
Add FlintAPI — self-hosted PPU-powered AI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ These providers offer a **permanently free tier** — no credit card required fo
 | Cohere | 6 | No | 256K | text | <a href="https://dashboard.cohere.com/api-keys" target="_blank" rel="noopener">→</a> |
 | Cerebras | 6 | No | 131K | text | <a href="https://cloud.cerebras.ai/" target="_blank" rel="noopener">→</a> |
 | LLM7.io | 6 | No | 131K | code, text | <a href="https://token.llm7.io" target="_blank" rel="noopener">→</a> |
+| FlintAPI | 2 | No | 131K | text | <a href="https://flintapi.ai" target="_blank" rel="noopener">→</a> |
 | Ollama Cloud | 6 | Registration | 262K | code, text | <a href="https://ollama.com/settings/keys" target="_blank" rel="noopener">→</a> |
 | Aion Labs | 5 | Registration | 131K | text | <a href="https://www.aionlabs.ai" target="_blank" rel="noopener">→</a> |
 | Google Gemini | 5 | No | 2M | text | <a href="https://aistudio.google.com/app/apikey" target="_blank" rel="noopener">→</a> |


### PR DESCRIPTION
Add [FlintAPI](https://flintapi.ai) to the free LLM APIs list.

FlintAPI offers:
- **Qwen2.5-72B & Llama 3.3 70B** on custom PPU silicon (16x PPU-ZW810E)
- OpenAI-compatible API — drop-in replacement
- **$2 free credit** on signup, no credit card required
- Referral program for community growth
- ~30% cheaper than aggregators for Qwen models