### PR TITLE
Add AnyAPI (anyapi.ai) as free inference provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ These providers offer a **permanently free tier** — no credit card required fo
 | NVIDIA NIM | 75 | Phone verification | 1M | audio, image, reasoning, text, video | <a href="https://build.nvidia.com/settings/api-keys" target="_blank" rel="noopener">→</a> |
 | Groq | 14 | No | 262K | image, reasoning, text | <a href="https://console.groq.com/keys" target="_blank" rel="noopener">→</a> |
 | GitHub Models | 13 | No | 1M | image, pdf, reasoning, text | <a href="https://github.com/marketplace/models" target="_blank" rel="noopener">→</a> |
+| AnyAPI | 15 | No | 1M | code, image, reasoning, text | <a href="https://dash.anyapi.ai/" target="_blank" rel="noopener">→</a> |
 | Cloudflare Workers AI | 13 | No | 10M | code, image, reasoning, text, video | <a href="https://dash.cloudflare.com/profile/api-tokens" target="_blank" rel="noopener">→</a> |
 | OVHcloud AI Endpoints | 12 | Registration | 262K | audio, code, image, reasoning, text, video | <a href="https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/" target="_blank" rel="noopener">→</a> |
 | Mistral AI | 9 | No | 256K | code, image, text | <a href="https://console.mistral.ai/api-keys" target="_blank" rel="noopener">→</a> |
@@ -180,6 +181,7 @@ Providers that periodically renew free credits.
 | OpenRouter | `https://openrouter.ai/api/v1` | <a href="https://openrouter.ai/workspaces/default/keys" target="_blank" rel="noopener">Get Key →</a> | Registration |
 | Groq | `https://api.groq.com/openai/v1` | <a href="https://console.groq.com/keys" target="_blank" rel="noopener">Get Key →</a> | No |
 | GitHub Models | `https://models.github.ai/inference` | <a href="https://github.com/marketplace/models" target="_blank" rel="noopener">Get Key →</a> | No |
+| AnyAPI | `https://api.anyapi.ai/v1` | <a href="https://dash.anyapi.ai/" target="_blank" rel="noopener">Get Key →</a> | No |
 | Cloudflare Workers AI | `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run` | <a href="https://dash.cloudflare.com/profile/api-tokens" target="_blank" rel="noopener">Get Key →</a> | No |
 | OVHcloud AI Endpoints | `https://oai.endpoints.kepler.ai.cloud.ovh.net/v1` | <a href="https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/" target="_blank" rel="noopener">Get Key →</a> | Registration |
 | Mistral AI | `https://api.mistral.ai/v1` | <a href="https://console.mistral.ai/api-keys" target="_blank" rel="noopener">Get Key →</a> | No |
@@ -224,6 +226,9 @@ Providers that periodically renew free credits.
 | GitHub Models | <a href="https://freellm.net/models/github-models/phi-4/" target="_blank" rel="noopener">Phi-4</a> | `Phi-4` | 131K | See provider |
 |  | <a href="https://freellm.net/models/github-models/mistral-large-2411/" target="_blank" rel="noopener">Mistral Large (24.11)</a> | `Mistral-large-2411` | 131K | See provider |
 |  | <a href="https://freellm.net/models/github-models/ai21-jamba-1-5-large/" target="_blank" rel="noopener">AI21 Jamba 1.5 Large</a> | `AI21-Jamba-1.5-Large` | 256K | See provider |
+| AnyAPI | <a href="https://freellm.net/models/openrouter/nvidia-nemotron-3-ultra-550b-a55b/" target="_blank" rel="noopener">Nemotron 3 Ultra (free)</a> | `nvidia/nemotron-3-ultra-550b-a55b:free` | 1M | 20 RPM, 200 RPD |
+|  | <a href="https://freellm.net/models/openrouter/meta-llama-llama-3-3-70b-instruct/" target="_blank" rel="noopener">Llama 3.3 70B (free)</a> | `meta-llama/llama-3.3-70b-instruct:free` | 131K | 20 RPM, 200 RPD |
+|  | <a href="https://freellm.net/models/openrouter/qwen-qwen3-coder/" target="_blank" rel="noopener">Qwen3 Coder (free)</a> | `qwen/qwen3-coder:free` | 1M | 20 RPM, 200 RPD |
 | Cloudflare Workers AI | <a href="https://freellm.net/models/cloudflare-workers-ai/mistral-mistral-7b-instruct-v0-1/" target="_blank" rel="noopener">Mistral 7B</a> | `@cf/mistral/mistral-7b-instruct-v0.1` | 32K | See provider |
 |  | <a href="https://freellm.net/models/cloudflare-workers-ai/qwen-qwen1-5-7b-chat/" target="_blank" rel="noopener">Qwen 1.5 7B</a> | `@cf/qwen/qwen1.5-7b-chat` | 32K | See provider |
 |  | <a href="https://freellm.net/models/cloudflare-workers-ai/cf-meta-llama-3-3-70b-instruct-fp8-fast/" target="_blank" rel="noopener">@cf/meta/llama-3.3-70b-instruct-fp8-fast</a> | `cf-meta-llama-3-3-70b-instruct-fp8-fast` | 131K | 10K neurons/day (shared) |


### PR DESCRIPTION
Adds [AnyAPI](https://anyapi.ai) - a free inference provider with OpenAI-compatible API, no credit card required.

- 15+ free models with `:free` suffix
- 20 RPM, 200 RPD rate limits
- No credit card required for free tier

Models include llama-3.3-70b-instruct, nemotron-3-ultra-550b-a55b, qwen3-coder and more.