### PR TITLE
Add automated API health checker script and status report

### DIFF
--- a/active_free_llm_apis_report.json
+++ b/active_free_llm_apis_report.json
@@ -1,0 +1,873 @@
+{
+  "generated_at": "2026-08-28T14:26:06.840588+00:00",
+  "source": "README.md",
+  "summary": {
+    "total_providers": 31,
+    "active": 29,
+    "degraded": 1,
+    "offline": 0,
+    "unknown": 1,
+    "total_model_ids": 84
+  },
+  "providers": [
+    {
+      "provider": "NVIDIA NIM",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://integrate.api.nvidia.com/v1",
+      "get_key_url": "https://build.nvidia.com/settings/api-keys",
+      "credit_card": "Phone verification",
+      "free_models_count": 126,
+      "model_ids": [
+        "z-ai/glm-5.2",
+        "poolside/laguna-xs-2.1",
+        "z-ai/glm-5.1"
+      ],
+      "api_probe": {
+        "url": "https://integrate.api.nvidia.com/v1",
+        "status": 404,
+        "elapsed": 0.36,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://build.nvidia.com/settings/api-keys",
+        "status": 200,
+        "elapsed": 0.73,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "ModelScope",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api-inference.modelscope.cn/v1",
+      "get_key_url": "https://modelscope.cn/my/myaccesstoken",
+      "credit_card": "Registration",
+      "free_models_count": 59,
+      "model_ids": [
+        "MiniMax/MiniMax-M2.5",
+        "qwen-qwen3-5-35b-a3b",
+        "qwen-qwen3-5-27b"
+      ],
+      "api_probe": {
+        "url": "https://api-inference.modelscope.cn/v1",
+        "status": 404,
+        "elapsed": 3.47,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://modelscope.cn/my/myaccesstoken",
+        "status": 200,
+        "elapsed": 2.31,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Cloudflare Workers AI",
+      "status": "Active",
+      "reason": "API reachable (HTTP 403)",
+      "base_url": "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run",
+      "get_key_url": "https://dash.cloudflare.com/profile/api-tokens",
+      "credit_card": "No",
+      "free_models_count": 40,
+      "model_ids": [
+        "@cf/mistral/mistral-7b-instruct-v0.1",
+        "@cf/qwen/qwen1.5-7b-chat",
+        "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
+      ],
+      "api_probe": {
+        "url": "https://api.cloudflare.com/client/v4/accounts",
+        "status": 403,
+        "elapsed": 0.49,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://dash.cloudflare.com/profile/api-tokens",
+        "status": 403,
+        "elapsed": 0.32,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "OpenRouter",
+      "status": "Active",
+      "reason": "API reachable (HTTP 200)",
+      "base_url": "https://openrouter.ai/api/v1",
+      "get_key_url": "https://openrouter.ai/workspaces/default/keys",
+      "credit_card": "Registration",
+      "free_models_count": 29,
+      "model_ids": [
+        "nvidia/nemotron-3-ultra-550b-a55b:free",
+        "poolside/laguna-m.1:free",
+        "nvidia/nemotron-3-super-120b-a12b:free"
+      ],
+      "api_probe": {
+        "url": "https://openrouter.ai/api/v1",
+        "status": 200,
+        "elapsed": 0.68,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://openrouter.ai/workspaces/default/keys",
+        "status": 200,
+        "elapsed": 0.85,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Google Gemini",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://generativelanguage.googleapis.com/v1beta",
+      "get_key_url": "https://aistudio.google.com/app/apikey",
+      "credit_card": "No",
+      "free_models_count": 17,
+      "model_ids": [
+        "gemini-3.6-flash",
+        "gemini-3.5-flash",
+        "gemini-3.5-flash-lite"
+      ],
+      "api_probe": {
+        "url": "https://generativelanguage.googleapis.com/v1beta",
+        "status": 404,
+        "elapsed": 0.7,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://aistudio.google.com/app/apikey",
+        "status": 200,
+        "elapsed": 2.13,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "GitHub Models",
+      "status": "Active",
+      "reason": "API reachable (HTTP 410)",
+      "base_url": "https://models.github.ai/inference",
+      "get_key_url": "https://github.com/marketplace/models",
+      "credit_card": "No",
+      "free_models_count": 16,
+      "model_ids": [
+        "Phi-4",
+        "Mistral-large-2411",
+        "AI21-Jamba-1.5-Large"
+      ],
+      "api_probe": {
+        "url": "https://models.github.ai/inference",
+        "status": 410,
+        "elapsed": 0.98,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://github.com/marketplace/models",
+        "status": 200,
+        "elapsed": 0.62,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "LLM7.io",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.llm7.io/v1",
+      "get_key_url": "https://token.llm7.io",
+      "credit_card": "No",
+      "free_models_count": 16,
+      "model_ids": [
+        "deepseek-r1-0528",
+        "deepseek-v3.2",
+        "gpt-4o-mini"
+      ],
+      "api_probe": {
+        "url": "https://api.llm7.io/v1",
+        "status": 404,
+        "elapsed": 0.43,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://token.llm7.io",
+        "status": 200,
+        "elapsed": 0.17,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "OVHcloud AI Endpoints",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
+      "get_key_url": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
+      "credit_card": "Registration",
+      "free_models_count": 14,
+      "model_ids": [
+        "qwen3.5-397b-a17b",
+        "meta-llama-3_3-70b-instruct",
+        "qwen3.6-27b"
+      ],
+      "api_probe": {
+        "url": "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
+        "status": 404,
+        "elapsed": 0.82,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
+        "status": 307,
+        "elapsed": 2.21,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Ollama Cloud",
+      "status": "Active",
+      "reason": "API reachable (HTTP 200)",
+      "base_url": "https://api.ollama.com",
+      "get_key_url": "https://ollama.com/settings/keys",
+      "credit_card": "Registration",
+      "free_models_count": 13,
+      "model_ids": [
+        "minimax-m3",
+        "gpt-oss:20b",
+        "nemotron-3-ultra"
+      ],
+      "api_probe": {
+        "url": "https://api.ollama.com",
+        "status": 200,
+        "elapsed": 0.72,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://ollama.com/settings/keys",
+        "status": 200,
+        "elapsed": 2.57,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Groq",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.groq.com/openai/v1",
+      "get_key_url": "https://console.groq.com/keys",
+      "credit_card": "No",
+      "free_models_count": 12,
+      "model_ids": [
+        "moonshotai/kimi-k2-instruct",
+        "moonshotai/kimi-k2-instruct-0905",
+        "groq/compound"
+      ],
+      "api_probe": {
+        "url": "https://api.groq.com/openai/v1",
+        "status": 404,
+        "elapsed": 0.97,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://console.groq.com/keys",
+        "status": 200,
+        "elapsed": 0.88,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Mistral AI",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.mistral.ai/v1",
+      "get_key_url": "https://console.mistral.ai/api-keys",
+      "credit_card": "No",
+      "free_models_count": 12,
+      "model_ids": [
+        "open-mistral-7b",
+        "open-mixtral-8x7b",
+        "mistral-medium-3-5-128b"
+      ],
+      "api_probe": {
+        "url": "https://api.mistral.ai/v1",
+        "status": 404,
+        "elapsed": 0.21,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://console.mistral.ai/api-keys",
+        "status": 307,
+        "elapsed": 6.12,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Cohere",
+      "status": "Active",
+      "reason": "API reachable (HTTP 401)",
+      "base_url": "https://api.cohere.com/v2",
+      "get_key_url": "https://dashboard.cohere.com/api-keys",
+      "credit_card": "No",
+      "free_models_count": 12,
+      "model_ids": [
+        "command-a-218b",
+        "command-a-111b",
+        "command-r"
+      ],
+      "api_probe": {
+        "url": "https://api.cohere.com/v2",
+        "status": 401,
+        "elapsed": 0.57,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://dashboard.cohere.com/api-keys",
+        "status": 200,
+        "elapsed": 1.18,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Kilo Code",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.kilo.ai/api/gateway",
+      "get_key_url": "https://kilo.ai",
+      "credit_card": "No",
+      "free_models_count": 12,
+      "model_ids": [
+        "nvidia/nemotron-3-ultra-550b-a55b:free",
+        "stepfun/step-3.7-flash:free",
+        "nvidia/nemotron-3-super-120b-a12b:free"
+      ],
+      "api_probe": {
+        "url": "https://api.kilo.ai/api/gateway",
+        "status": 404,
+        "elapsed": 0.34,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://kilo.ai",
+        "status": 200,
+        "elapsed": 1.07,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "OpenCode Zen",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://opencode.ai/zen/v1",
+      "get_key_url": "https://opencode.ai/auth",
+      "credit_card": "Registration",
+      "free_models_count": 12,
+      "model_ids": [
+        "big-pickle",
+        "deepseek-v4-flash-free",
+        "mimo-v2.5-free"
+      ],
+      "api_probe": {
+        "url": "https://opencode.ai/zen/v1",
+        "status": 404,
+        "elapsed": 0.65,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://opencode.ai/auth",
+        "status": 200,
+        "elapsed": 1.59,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Aion Labs",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.aionlabs.ai/v1",
+      "get_key_url": "https://www.aionlabs.ai",
+      "credit_card": "Registration",
+      "free_models_count": 7,
+      "model_ids": [
+        "aion-2-5",
+        "aion-2-0",
+        "aion-rp-1-0-8b"
+      ],
+      "api_probe": {
+        "url": "https://api.aionlabs.ai/v1",
+        "status": 404,
+        "elapsed": 0.37,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://www.aionlabs.ai",
+        "status": 200,
+        "elapsed": 0.4,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Hugging Face",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://router.huggingface.co/v1",
+      "get_key_url": "https://huggingface.co/settings/tokens",
+      "credit_card": "No",
+      "free_models_count": 7,
+      "model_ids": [
+        "meta-llama-3-1-8b-instruct",
+        "gemma-3-4b-it",
+        "qwen2-5-coder-7b-instruct"
+      ],
+      "api_probe": {
+        "url": "https://router.huggingface.co/v1",
+        "status": 404,
+        "elapsed": 0.52,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://huggingface.co/settings/tokens",
+        "status": 200,
+        "elapsed": 0.89,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Cerebras",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.cerebras.ai/v1",
+      "get_key_url": "https://cloud.cerebras.ai/",
+      "credit_card": "No",
+      "free_models_count": 6,
+      "model_ids": [
+        "llama3.1-70b",
+        "zai-glm-4.7"
+      ],
+      "api_probe": {
+        "url": "https://api.cerebras.ai/v1",
+        "status": 404,
+        "elapsed": 0.56,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://cloud.cerebras.ai/",
+        "status": 200,
+        "elapsed": 0.42,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Agnes AI",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://apihub.agnes-ai.com/v1",
+      "get_key_url": "https://platform.agnes-ai.com/settings/apiKeys",
+      "credit_card": "Registration",
+      "free_models_count": 5,
+      "model_ids": [
+        "agnes-1.5-flash",
+        "agnes-2.0-flash",
+        "agnes-image-2.0-flash"
+      ],
+      "api_probe": {
+        "url": "https://apihub.agnes-ai.com/v1",
+        "status": 404,
+        "elapsed": 0.82,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://platform.agnes-ai.com/settings/apiKeys",
+        "status": 200,
+        "elapsed": 0.38,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Alibaba Cloud Model Studio",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      "get_key_url": "https://bailian.console.alibabacloud.com/?apiKey=1",
+      "credit_card": "Registration",
+      "free_models_count": 5,
+      "model_ids": [
+        "qwen3-max",
+        "qwen3-plus",
+        "qwen3-vl-plus"
+      ],
+      "api_probe": {
+        "url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        "status": 404,
+        "elapsed": 0.76,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://bailian.console.alibabacloud.com/?apiKey=1",
+        "status": 200,
+        "elapsed": 1.21,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Z AI (Zhipu AI)",
+      "status": "Active",
+      "reason": "API reachable (HTTP 401)",
+      "base_url": "https://open.bigmodel.cn/api/paas/v4",
+      "get_key_url": "https://open.bigmodel.cn/usercenter/apikeys",
+      "credit_card": "No",
+      "free_models_count": 4,
+      "model_ids": [
+        "glm-4.7",
+        "glm-4.5",
+        "glm-4.6"
+      ],
+      "api_probe": {
+        "url": "https://open.bigmodel.cn/api/paas/v4",
+        "status": 401,
+        "elapsed": 2.56,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://open.bigmodel.cn/usercenter/apikeys",
+        "status": 200,
+        "elapsed": 2.53,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "SambaNova",
+      "status": "Active",
+      "reason": "API reachable (HTTP 405)",
+      "base_url": "https://api.sambanova.ai/v1",
+      "get_key_url": "https://cloud.sambanova.ai/apis",
+      "credit_card": "Registration",
+      "free_models_count": 4,
+      "model_ids": [
+        "deepseek-v3-1",
+        "deepseek-v3-2-preview",
+        "minimax-m2-7"
+      ],
+      "api_probe": {
+        "url": "https://api.sambanova.ai/v1",
+        "status": 405,
+        "elapsed": 1.54,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://cloud.sambanova.ai/apis",
+        "status": 200,
+        "elapsed": 0.9,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "SiliconFlow",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.siliconflow.cn/v1",
+      "get_key_url": "https://cloud.siliconflow.cn/account/ak",
+      "credit_card": "Registration",
+      "free_models_count": 3,
+      "model_ids": [
+        "deepseek-ai-deepseek-r1-distill-qwen-7b",
+        "abbreviation",
+        "deepseek-ai-deepseek-ocr"
+      ],
+      "api_probe": {
+        "url": "https://api.siliconflow.cn/v1",
+        "status": 404,
+        "elapsed": 1.79,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://cloud.siliconflow.cn/account/ak",
+        "status": 200,
+        "elapsed": 5.55,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "xAI",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.x.ai/v1",
+      "get_key_url": "https://console.x.ai",
+      "credit_card": "Registration",
+      "free_models_count": 3,
+      "model_ids": [
+        "grok-4-3",
+        "grok-4-1-fast",
+        "grok-3-mini"
+      ],
+      "api_probe": {
+        "url": "https://api.x.ai/v1",
+        "status": 404,
+        "elapsed": 0.33,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://console.x.ai",
+        "status": 403,
+        "elapsed": 0.1,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Cline",
+      "status": "Unknown",
+      "reason": "no base URL in README",
+      "base_url": "",
+      "get_key_url": "",
+      "credit_card": "Registration",
+      "free_models_count": 3,
+      "model_ids": [
+        "deepseek/deepseek-v4-flash",
+        "poolside/laguna-s-2.1:free",
+        "z-ai/glm-5.3-flash"
+      ],
+      "api_probe": {
+        "url": "",
+        "status": null,
+        "elapsed": null,
+        "error": "not-probed",
+        "ok": false
+      },
+      "key_probe": {
+        "url": "",
+        "status": null,
+        "elapsed": null,
+        "error": "n/a",
+        "ok": false
+      }
+    },
+    {
+      "provider": "Chutes.ai",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.chutes.ai/v1",
+      "get_key_url": "https://chutes.ai/",
+      "credit_card": "Registration",
+      "free_models_count": 2,
+      "model_ids": [
+        "deepseek-ai/DeepSeek-R1",
+        "meta-llama/Meta-Llama-3.1-70B-Instruct"
+      ],
+      "api_probe": {
+        "url": "https://api.chutes.ai/v1",
+        "status": 404,
+        "elapsed": 0.61,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://chutes.ai/",
+        "status": 200,
+        "elapsed": 0.63,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Glhf.chat",
+      "status": "Degraded",
+      "reason": "API returned HTTP 522",
+      "base_url": "https://glhf.chat/api/openai/v1",
+      "get_key_url": "https://glhf.chat/",
+      "credit_card": "Registration",
+      "free_models_count": 2,
+      "model_ids": [
+        "meta-llama/Meta-Llama-3.1-70B-Instruct",
+        "mistralai/Mixtral-8x7B-Instruct-v0.1"
+      ],
+      "api_probe": {
+        "url": "https://glhf.chat/api/openai/v1",
+        "status": 522,
+        "elapsed": 19.87,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://glhf.chat/",
+        "status": 522,
+        "elapsed": 19.82,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Grok (xAI)",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.x.ai/v1",
+      "get_key_url": "https://console.x.ai/",
+      "credit_card": "Registration",
+      "free_models_count": 2,
+      "model_ids": [
+        "grok-2",
+        "grok-2-mini"
+      ],
+      "api_probe": {
+        "url": "https://api.x.ai/v1",
+        "status": 404,
+        "elapsed": 0.35,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://console.x.ai/",
+        "status": 403,
+        "elapsed": 0.1,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "AI21 Labs",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.ai21.com/studio/v1",
+      "get_key_url": "https://studio.ai21.com/account/api-key",
+      "credit_card": "Registration",
+      "free_models_count": 2,
+      "model_ids": [
+        "jamba-large-1-7",
+        "jamba-mini-2"
+      ],
+      "api_probe": {
+        "url": "https://api.ai21.com/studio/v1",
+        "status": 404,
+        "elapsed": 0.55,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://studio.ai21.com/account/api-key",
+        "status": 200,
+        "elapsed": 0.36,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "DeepSeek",
+      "status": "Active",
+      "reason": "API reachable (HTTP 401)",
+      "base_url": "https://api.deepseek.com/v1",
+      "get_key_url": "https://platform.deepseek.com/api_keys",
+      "credit_card": "Registration",
+      "free_models_count": 2,
+      "model_ids": [
+        "deepseek-chat-v3-2",
+        "deepseek-reasoner-r1"
+      ],
+      "api_probe": {
+        "url": "https://api.deepseek.com/v1",
+        "status": 401,
+        "elapsed": 0.43,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://platform.deepseek.com/api_keys",
+        "status": 202,
+        "elapsed": 0.35,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Nscale",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://inference.api.nscale.com/v1",
+      "get_key_url": "https://console.nscale.com/",
+      "credit_card": "Registration",
+      "free_models_count": 2,
+      "model_ids": [
+        "llama-3-3-70b-instruct",
+        "deepseek-r1-distill-llama-70b"
+      ],
+      "api_probe": {
+        "url": "https://inference.api.nscale.com/v1",
+        "status": 404,
+        "elapsed": 0.5,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://console.nscale.com/",
+        "status": 200,
+        "elapsed": 0.52,
+        "error": null,
+        "ok": true
+      }
+    },
+    {
+      "provider": "Nebius",
+      "status": "Active",
+      "reason": "API reachable (HTTP 404)",
+      "base_url": "https://api.studio.nebius.com/v1",
+      "get_key_url": "https://studio.nebius.com/settings/api-keys",
+      "credit_card": "Registration",
+      "free_models_count": 1,
+      "model_ids": [
+        "qwen3-235b-a22b"
+      ],
+      "api_probe": {
+        "url": "https://api.studio.nebius.com/v1",
+        "status": 404,
+        "elapsed": 0.77,
+        "error": null,
+        "ok": true
+      },
+      "key_probe": {
+        "url": "https://studio.nebius.com/settings/api-keys",
+        "status": 200,
+        "elapsed": 1.49,
+        "error": null,
+        "ok": true
+      }
+    }
+  ]
+}

--- a/api_health_checker.py
+++ b/api_health_checker.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+api_health_checker.py
+=====================================================================
+Standalone health-checker for the awesome-free-llm-apis repository.
+
+What it does
+------------
+1. Parses README.md (English) and extracts, per provider:
+     - Provider name
+     - Base endpoint  (OpenAI-compatible API base URL)
+     - "Get API Key" URL  (provider's key/signup page)
+     - Model IDs  (from the "Best Free Models by Provider" table)
+     - Provider directory URL (freellm.net link)
+2. Probes every endpoint over HTTP (concurrently) and classifies it:
+     - ACTIVE    -> server answered (any 2xx/3xx/4xx incl. 401/403/404)
+     - DEGRADED  -> 5xx, HTTP 429, or very slow (>5s), or API down but
+                    provider key-page still up
+     - OFFLINE   -> DNS / connection / timeout failure on BOTH the API
+                    and the provider key page
+3. Writes a JSON report (active_free_llm_apis_report.json) and prints a
+   clean table of verified-active providers.
+
+Design notes
+------------
+* Standard library only (urllib) so it re-runs anywhere with no pip.
+* Re-runnable: `python3 api_health_checker.py` writes report next to it.
+* The README sections are delimited by stable HTML comment markers
+  (BEGIN_QUICK_REF / END_QUICK_REF, BEGIN_BEST_MODELS / END_BEST_MODELS,
+  BEGIN_PERMANENT_FREE / END_PERMANENT_FREE, BEGIN_RENEWABLE / END_RENEWABLE)
+  so parsing is robust to row re-ordering.
+
+Usage
+-----
+    python3 api_health_checker.py            # full run, writes report
+    python3 api_health_checker.py --quiet    # no table, just JSON
+    python3 api_health_checker.py --timeout 8
+"""
+
+import argparse
+import concurrent.futures as cf
+import json
+import os
+import re
+import socket
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+HERE = os.path.dirname(os.path.abspath(__file__))
+README_PATH = os.path.join(HERE, "README.md")
+REPORT_PATH = os.path.join(HERE, "active_free_llm_apis_report.json")
+
+# A response slower than this (seconds) is flagged DEGRADED even if 2xx.
+SLOW_THRESHOLD = 5.0
+HTTP_TIMEOUT = 20.0
+CONCURRENCY = 12
+USER_AGENT = "Mozilla/5.0 (compatible; FreeLLMHealthCheck/1.0)"
+
+
+# --------------------------------------------------------------------------
+# README parsing
+# --------------------------------------------------------------------------
+def _read_section(text: str, begin: str, end: str) -> str:
+    """Extract the markdown table that sits between two comment markers."""
+    pat = re.compile(r"<!--\s*BEGIN_%s\s*-->(.*?)<!--\s*END_%s\s*-->" % (begin, end),
+                     re.DOTALL)
+    m = pat.search(text)
+    return m.group(1) if m else ""
+
+
+def _table_rows(section: str):
+    """Yield parsed cells for each markdown table row (skips the header)."""
+    rows = []
+    for line in section.splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        if re.match(r"^\|[\s:|-]+\|$", line):  # separator row
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        rows.append(cells)
+    return rows
+
+
+def _first_link(text: str):
+    """Return (url, label) of the first markdown/html link in a cell."""
+    m = re.search(r'<a\s+href="([^"]+)"[^>]*>(.*?)</a>', text, re.IGNORECASE | re.DOTALL)
+    if m:
+        return m.group(1).strip(), re.sub(r"<[^>]+>", "", m.group(2)).strip()
+    m = re.search(r"\[([^\]]+)\]\(([^)]+)\)", text)
+    if m:
+        return m.group(2).strip(), m.group(1).strip()
+    return None, None
+
+
+def _backtick(text: str):
+    """Pull the first `backtick` content from a cell (base URL / model id)."""
+    m = re.search(r"`([^`]+)`", text)
+    return m.group(1).strip() if m else ""
+
+
+def parse_readme(path: str):
+    """Return a dict: provider_name -> provider record."""
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+
+    providers = {}
+
+    # ---- Quick Reference: Provider | Base URL | Get Key | Credit Card? ----
+    qr = _table_rows(_read_section(text, "QUICK_REF", "QUICK_REF"))
+    for cells in qr:
+        if len(cells) < 4:
+            continue
+        name = re.sub(r"<[^>]+>", "", cells[0]).strip()
+        if not name or name.lower() == "provider":
+            continue
+        base_url = _backtick(cells[1])
+        key_url, _ = _first_link(cells[2])
+        cc = re.sub(r"<[^>]+>", "", cells[3]).strip()
+        providers.setdefault(name, {
+            "provider": name,
+            "base_url": base_url,
+            "get_key_url": key_url or "",
+            "credit_card": cc,
+            "model_ids": [],
+        })
+
+    # ---- Best Free Models: Provider | Model | Model ID | Context | Rate ----
+    bm = _table_rows(_read_section(text, "BEST_MODELS", "BEST_MODELS"))
+    current = None
+    for cells in bm:
+        if len(cells) < 5:
+            continue
+        pname = re.sub(r"<[^>]+>", "", cells[0]).strip()
+        if pname.lower() == "provider":
+            continue
+        if pname:
+            current = pname
+        model_id = _backtick(cells[2])
+        if current and model_id:
+            rec = providers.get(current)
+            if rec and model_id not in rec["model_ids"]:
+                rec["model_ids"].append(model_id)
+
+    # ---- Provider directory: name | ... | Get Key (for provider URLs) ----
+    for marker in ("PERMANENT_FREE", "RENEWABLE"):
+        pd = _table_rows(_read_section(text, marker, marker))
+        for cells in pd:
+            if len(cells) < 6:
+                continue
+            name = re.sub(r"<[^>]+>", "", cells[0]).strip()
+            rec = providers.get(name)
+            if not rec:
+                continue
+            key_url, _ = _first_link(cells[-1])
+            if key_url and not rec["get_key_url"]:
+                rec["get_key_url"] = key_url
+            rec.setdefault("free_models_count",
+                           _to_int(re.sub(r"<[^>]+>", "", cells[1])))
+
+    return providers
+
+
+def _to_int(s: str):
+    m = re.search(r"\d+", s)
+    return int(m.group(0)) if m else None
+
+
+# --------------------------------------------------------------------------
+# HTTP probing
+# --------------------------------------------------------------------------
+def _normalize(url: str):
+    """Handle placeholder paths like Cloudflare's {account_id}."""
+    if not url:
+        return None
+    if "{" in url:
+        url = url.split("{")[0].rstrip("/")
+    return url or None
+
+
+def probe(url: str, timeout: float = HTTP_TIMEOUT):
+    """GET a URL (no auth). Returns dict with status/elapsed/error."""
+    url = _normalize(url)
+    result = {"url": url, "status": None, "elapsed": None,
+              "error": None, "ok": False}
+    if not url:
+        result["error"] = "no-url"
+        return result
+    ctx = ssl.create_default_context()
+    req = urllib.request.Request(url, method="GET",
+                                 headers={"User-Agent": USER_AGENT,
+                                          "Accept": "*/*"})
+    t0 = time.time()
+    try:
+        resp = urllib.request.urlopen(req, timeout=timeout, context=ctx)
+        result["status"] = resp.status
+        result["ok"] = True
+    except urllib.error.HTTPError as e:
+        result["status"] = e.code
+        result["ok"] = True  # server answered -> reachable
+    except (urllib.error.URLError, socket.timeout, ssl.SSLError,
+            ConnectionError, TimeoutError) as e:
+        result["error"] = _short_err(e)
+    finally:
+        result["elapsed"] = round(time.time() - t0, 2)
+    return result
+
+
+def _short_err(e):
+    msg = str(getattr(e, "reason", e)) or type(e).__name__
+    msg = re.sub(r"\[.*?\]", "", msg).strip()
+    return msg[:80]
+
+
+def classify(api_probe, key_probe):
+    """Return (status, reason) from the two probes."""
+    api_ok = api_probe.get("ok")
+    if api_ok:
+        code = api_probe.get("status")
+        if code and 500 <= code < 600:
+            return "Degraded", f"API returned HTTP {code}"
+        if code == 429:
+            return "Degraded", "API returned HTTP 429 (rate limited)"
+        if api_probe.get("elapsed", 0) and api_probe["elapsed"] > SLOW_THRESHOLD:
+            return "Degraded", f"slow response ({api_probe['elapsed']}s)"
+        return "Active", f"API reachable (HTTP {code})"
+
+    # API unreachable -> check provider key page
+    if key_probe.get("ok"):
+        return "Degraded", "API unreachable but provider site is up"
+    return "Offline", f"API unreachable ({api_probe.get('error')})"
+
+
+# --------------------------------------------------------------------------
+# Orchestration
+# --------------------------------------------------------------------------
+def run(timeout: float = HTTP_TIMEOUT):
+    providers = parse_readme(README_PATH)
+    urls = []
+    for rec in providers.values():
+        api = _normalize(rec.get("base_url"))
+        key = _normalize(rec.get("get_key_url"))
+        if api:
+            urls.append(("api", rec["provider"], api))
+        if key and key != api:
+            urls.append(("key", rec["provider"], key))
+
+    probes = {}
+    with cf.ThreadPoolExecutor(max_workers=CONCURRENCY) as ex:
+        futs = {ex.submit(probe, u, timeout): (kind, name, u)
+                for kind, name, u in urls}
+        for fut in cf.as_completed(futs):
+            kind, name, u = futs[fut]
+            probes[(kind, name)] = fut.result()
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": "README.md",
+        "summary": {},
+        "providers": [],
+    }
+    status_counts = {"Active": 0, "Degraded": 0, "Offline": 0, "Unknown": 0}
+
+    for name, rec in providers.items():
+        api_p = probes.get(("api", name), {"url": rec.get("base_url"),
+                                           "status": None, "elapsed": None,
+                                           "error": "not-probed", "ok": False})
+        key_p = probes.get(("key", name), {"url": rec.get("get_key_url"),
+                                           "status": None, "elapsed": None,
+                                           "error": "n/a", "ok": False})
+        if not rec.get("base_url"):
+            status, reason = "Unknown", "no base URL in README"
+            status_counts["Unknown"] += 1
+        else:
+            status, reason = classify(api_p, key_p)
+            status_counts[status] = status_counts.get(status, 0) + 1
+
+        report["providers"].append({
+            "provider": name,
+            "status": status,
+            "reason": reason,
+            "base_url": rec.get("base_url", ""),
+            "get_key_url": rec.get("get_key_url", ""),
+            "credit_card": rec.get("credit_card", ""),
+            "free_models_count": rec.get("free_models_count"),
+            "model_ids": rec.get("model_ids", []),
+            "api_probe": _trim(api_p),
+            "key_probe": _trim(key_p),
+        })
+
+    report["summary"] = {
+        "total_providers": len(providers),
+        "active": status_counts.get("Active", 0),
+        "degraded": status_counts.get("Degraded", 0),
+        "offline": status_counts.get("Offline", 0),
+        "unknown": status_counts.get("Unknown", 0),
+        "total_model_ids": sum(len(r["model_ids"]) for r in providers.values()),
+    }
+    return report
+
+
+def _trim(p):
+    return {"url": p.get("url"), "status": p.get("status"),
+            "elapsed": p.get("elapsed"), "error": p.get("error"),
+            "ok": p.get("ok")}
+
+
+def print_table(report):
+    provs = report["providers"]
+    active = [p for p in provs if p["status"] == "Active"]
+    degraded = [p for p in provs if p["status"] == "Degraded"]
+    offline = [p for p in provs if p["status"] == "Offline"]
+    unknown = [p for p in provs if p["status"] == "Unknown"]
+
+    print("\n" + "=" * 78)
+    print("  VERIFIED ACTIVE FREE LLM API PROVIDERS")
+    print("=" * 78)
+    hdr = f"{'#':>2}  {'Provider':<26} {'Base URL':<48}"
+    print(hdr)
+    print("-" * 78)
+    for i, p in enumerate(active, 1):
+        base = (p["base_url"] or "-")[:48]
+        print(f"{i:>2}  {p['provider']:<26} {base:<48}")
+    print("-" * 78)
+    print(f"ACTIVE: {len(active)}   DEGRADED: {len(degraded)}   "
+          f"OFFLINE: {len(offline)}   UNKNOWN: {len(unknown)}")
+    print(f"Total providers parsed: {report['summary']['total_providers']}   "
+          f"Model IDs indexed: {report['summary']['total_model_ids']}")
+
+    if degraded:
+        print("\n  DEGRADED (reachable but unhealthy / API down, site up):")
+        for p in degraded:
+            print(f"    - {p['provider']:<26} {p['reason']}")
+    if offline:
+        print("\n  OFFLINE (no response from API or site):")
+        for p in offline:
+            print(f"    - {p['provider']:<26} {p['reason']}")
+    if unknown:
+        print("\n  UNKNOWN (no base URL to test):")
+        for p in unknown:
+            print(f"    - {p['provider']:<26} {p['reason']}")
+    print("=" * 78 + "\n")
+
+
+def main():
+    global README_PATH, REPORT_PATH
+    ap = argparse.ArgumentParser(description="Free LLM API health checker")
+    ap.add_argument("--quiet", action="store_true", help="skip table print")
+    ap.add_argument("--timeout", type=float, default=HTTP_TIMEOUT)
+    ap.add_argument("--readme", default=README_PATH)
+    ap.add_argument("--out", default=REPORT_PATH)
+    args = ap.parse_args()
+
+    README_PATH = args.readme
+    REPORT_PATH = args.out
+
+    if not os.path.exists(README_PATH):
+        print(f"ERROR: README not found at {README_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[*] Parsing {README_PATH} ...")
+    report = run(args.timeout)
+
+    with open(REPORT_PATH, "w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2, ensure_ascii=False)
+    print(f"[*] Wrote report -> {REPORT_PATH}")
+
+    if not args.quiet:
+        print_table(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Add automated API health checker script and live status report

## Summary
Adds two files that let anyone verify which free LLM API providers from this
list are currently reachable, without manual clicking:

- **`api_health_checker.py`** — standalone, stdlib-only (no pip) tool that
  parses `README.md`, extracts every provider's base URL + model IDs, probes
  each endpoint concurrently, and classifies it **Active / Degraded / Offline**.
  Re-runnable any time: `python api_health_checker.py`.
- **`active_free_llm_apis_report.json`** — the live snapshot produced by the
  checker at commit time.

## Live health snapshot (generated 2026-08-28)
| Metric | Count |
|---|---|
| Total providers parsed | 31 |
| **Active** | 29 |
| **Degraded** | 1 |
| **Offline** | 0 |
| **Unknown** (no base URL in README) | 1 |
| Model IDs indexed | 84 |

### Notes
- **Glhf.chat** is `Degraded` — returns HTTP 522 (Cloudflare origin timeout);
  the server is present but unhealthy, not down.
- **Cline** is `Unknown` — the README lists it as a tooling integration with no
  direct base URL to probe.
- "Active" means the endpoint **answered** (2xx/3xx/4xx, including 401/403/404,
  which prove the service is up). Without API keys we can't call the models, but
  the services are confirmed reachable. Requests were made with no auth, a
  browser-like User-Agent, and a 20s timeout.

## How to reproduce
```bash
python api_health_checker.py            # full run, rewrites the JSON report
python api_health_checker.py --quiet    # JSON only
```

## Why
The list is refreshed daily from freellm.net, but "listed" ≠ "currently up".
This gives contributors and users a fast, scriptable way to confirm which
free endpoints are actually live before wiring them into a tool.

---
*Generated by `api_health_checker.py` — re-run to refresh this snapshot.*
