### PR TITLE
Add TeamoRouter: permanent free DeepSeek V4 Pro/Flash tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ These providers offer a **permanently free tier** — no credit card required fo
 | DeepSeek | 2 | Registration | 128K | text | <a href="https://platform.deepseek.com/api_keys" target="_blank" rel="noopener">→</a> |
 | Nscale | 2 | Registration | 128K | text | <a href="https://console.nscale.com/" target="_blank" rel="noopener">→</a> |
 | Nebius | 1 | Registration | 128K | text | <a href="https://studio.nebius.com/settings/api-keys" target="_blank" rel="noopener">→</a> |
+| TeamoRouter | 2 | Registration | 1M | reasoning, text | <a href="https://teamorouter.cn" target="_blank" rel="noopener">→</a> |
 <!-- END_PERMANENT_FREE -->
 
 ### 💰 Renewable Credits
@@ -209,6 +210,7 @@ Providers that periodically renew free credits.
 | DeepSeek | `https://api.deepseek.com/v1` | <a href="https://platform.deepseek.com/api_keys" target="_blank" rel="noopener">Get Key →</a> | Registration |
 | Nscale | `https://inference.api.nscale.com/v1` | <a href="https://console.nscale.com/" target="_blank" rel="noopener">Get Key →</a> | Registration |
 | Nebius | `https://api.studio.nebius.com/v1` | <a href="https://studio.nebius.com/settings/api-keys" target="_blank" rel="noopener">Get Key →</a> | Registration |
+| TeamoRouter | `https://api.teamorouter.cn/v1` | <a href="https://teamorouter.cn" target="_blank" rel="noopener">Get Key →</a> | Registration |
 <!-- END_QUICK_REF -->
 
 ## Best Free Models by Provider
@@ -301,6 +303,8 @@ Providers that periodically renew free credits.
 | Nscale | <a href="https://freellm.net/models/nscale/llama-3-3-70b-instruct/" target="_blank" rel="noopener">Llama-3.3-70B-Instruct</a> | `llama-3-3-70b-instruct` | 128K | Fair-use |
 |  | <a href="https://freellm.net/models/nscale/deepseek-r1-distill-llama-70b/" target="_blank" rel="noopener">DeepSeek-R1-Distill-Llama-70B</a> | `deepseek-r1-distill-llama-70b` | 128K | Fair-use |
 | Nebius | <a href="https://freellm.net/models/nebius/qwen3-235b-a22b/" target="_blank" rel="noopener">Qwen3-235B-A22B</a> | `qwen3-235b-a22b` | 128K | Tier-based |
+| TeamoRouter | <a href="https://teamorouter.cn" target="_blank" rel="noopener">DeepSeek V4 Pro (free)</a> | `deepseek-v4-pro-free` | 1M | 200 req/day |
+|  | <a href="https://teamorouter.cn" target="_blank" rel="noopener">DeepSeek V4 Flash (free)</a> | `deepseek-v4-flash-free` | 1M | 50 req/day |
 <!-- END_BEST_MODELS -->
 
 


### PR DESCRIPTION
Adds [TeamoRouter](https://teamorouter.cn) across the three provider tables, meeting the inclusion criteria (explicit permanent free tier, publicly accessible API, no trial-credit caveats):

**⚡ Permanent Free Tiers**
| Provider | Free Models | Credit Card? | Max Context | Modalities |
| --- | --- | --- | --- | --- |
| TeamoRouter | 2 | Registration (no card) | 1M | reasoning, text |

**Free models** — permanent tiers granted at registration, no credit card, same weights as the paid tier:
- `deepseek-v4-flash-free` — 1M context, 384K max output, 50 req/day (284B MoE, MIT license, thinking mode default)
- `deepseek-v4-pro-free` — 1M context, 200 req/day

**Base URL** `https://api.teamorouter.cn/v1` (OpenAI SDK-compatible). The endpoint also speaks the Anthropic Messages protocol natively, so the same key works as `ANTHROPIC_BASE_URL` for Claude Code or `OPENAI_BASE_URL` for Codex — relevant for your `code-examples/` Claude Code section, which currently needs the "use OpenRouter" workaround.

Caveat: quota/context figures are from the operator's published docs; happy to run a live probe request against both free model IDs if you want that confirmed before merging.

Useful links:
- https://teamorouter.cn (landing page)
- https://teamorouter.cn/docs (API docs)
- https://api.teamorouter.cn/v1 (base URL)